### PR TITLE
Fix Promo Panel

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -70,7 +70,7 @@ func (bot *Bot) Post() error {
 
 // GetComic gets a Comic's data from explosm.net/rcg
 func (bot *Bot) getComic() (*Comic, error) {
-	req, err := http.NewRequest("GET", "http://explosm.net/rcg", nil)
+	req, err := http.NewRequest("GET", "http://explosm.net/rcg?promo=false", nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
C&H are pushing a promo which locks the first panel to some dumb shit by default. Adding the `promo=false` query parameter stops this.